### PR TITLE
UF-2674 - Clean up sms-sender

### DIFF
--- a/src/integration-test/java/openapi/OpenApiSpecificationIT.java
+++ b/src/integration-test/java/openapi/OpenApiSpecificationIT.java
@@ -1,3 +1,5 @@
+package openapi;
+
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -27,7 +29,7 @@ import net.javacrumbs.jsonunit.core.internal.Options;
         "logging.level.se.sundsvall.dept44.payload=OFF"
     }
 )
-class GenerateOpenApiIT {
+class OpenApiSpecificationIT {
 
     private static final YAMLMapper YAML_MAPPER = new YAMLMapper();
 

--- a/src/main/java/se/sundsvall/smssender/api/SmsResource.java
+++ b/src/main/java/se/sundsvall/smssender/api/SmsResource.java
@@ -9,9 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.zalando.problem.Problem;
 
 import se.sundsvall.smssender.api.model.SendSmsRequest;
-import se.sundsvall.smssender.integration.SmsProperties;
-import se.sundsvall.smssender.integration.linkmobility.LinkMobilityService;
-import se.sundsvall.smssender.integration.telia.TeliaService;
+import se.sundsvall.smssender.api.model.SendSmsResponse;
+import se.sundsvall.smssender.integration.SmsService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -24,16 +23,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "SMS Resources")
 class SmsResource {
 
-    private final TeliaService teliaService;
-    private final LinkMobilityService linkMobilityService;
+    private final SmsService<?> smsService;
 
-    private final SmsProperties smsProperties;
-
-    SmsResource(final SmsProperties smsProperties, final TeliaService teliaService,
-            final LinkMobilityService linkMobilityService) {
-        this.teliaService = teliaService;
-        this.linkMobilityService = linkMobilityService;
-        this.smsProperties = smsProperties;
+    SmsResource(final SmsService<?> smsService) {
+        this.smsService = smsService;
     }
 
     @Operation(summary = "Send an SMS")
@@ -55,12 +48,11 @@ class SmsResource {
         )
     })
     @PostMapping("/send/sms")
-    ResponseEntity<Boolean> sendSms(@Valid @RequestBody SendSmsRequest sms) {
-        var response = switch (smsProperties.getProvider()) {
-            case TELIA -> teliaService.sendSms(sms);
-            case LINKMOBILITY -> linkMobilityService.sendSms(sms);
-        };
+    ResponseEntity<SendSmsResponse> sendSms(@Valid @RequestBody SendSmsRequest sms) {
+        var sent = smsService.sendSms(sms);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(SendSmsResponse.builder()
+            .withSent(sent)
+            .build());
     }
 }

--- a/src/main/java/se/sundsvall/smssender/api/model/SendSmsResponse.java
+++ b/src/main/java/se/sundsvall/smssender/api/model/SendSmsResponse.java
@@ -1,0 +1,18 @@
+package se.sundsvall.smssender.api.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+@Builder(setterPrefix = "with")
+public class SendSmsResponse {
+
+    private boolean sent;
+}

--- a/src/main/java/se/sundsvall/smssender/integration/Provider.java
+++ b/src/main/java/se/sundsvall/smssender/integration/Provider.java
@@ -20,7 +20,7 @@ public enum Provider {
         return value;
     }
 
-    static Provider fromValue(final String value) {
+    public static Provider fromValue(final String value) {
         return Arrays.stream(values())
                 .filter(provider -> provider.value.equalsIgnoreCase(value))
                 .findFirst()

--- a/src/main/java/se/sundsvall/smssender/integration/linkmobility/LinkMobilitySmsService.java
+++ b/src/main/java/se/sundsvall/smssender/integration/linkmobility/LinkMobilitySmsService.java
@@ -8,20 +8,23 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import se.sundsvall.smssender.api.model.SendSmsRequest;
+import se.sundsvall.smssender.integration.Provider;
 import se.sundsvall.smssender.integration.SmsService;
 import se.sundsvall.smssender.integration.linkmobility.domain.LinkMobilityResponse;
 import se.sundsvall.smssender.integration.linkmobility.domain.LinkMobilitySendSmsRequest;
 import se.sundsvall.smssender.integration.linkmobility.domain.ResponseStatus;
+import se.sundsvall.smssender.integration.support.annotation.ConditionalOnConfiguredProvider;
 
 @Service
-public class LinkMobilityService implements SmsService<LinkMobilitySendSmsRequest> {
+@ConditionalOnConfiguredProvider(Provider.LINKMOBILITY)
+public class LinkMobilitySmsService implements SmsService<LinkMobilitySendSmsRequest> {
 
     static final String PREFIX = "+46";
 
     private final LinkMobilityProperties properties;
     private final RestTemplate restTemplate;
 
-    public LinkMobilityService(
+    public LinkMobilitySmsService(
             LinkMobilityProperties properties,
             @Qualifier("integration.linkmobility.resttemplate") RestTemplate restTemplate) {
         this.properties = properties;
@@ -33,19 +36,19 @@ public class LinkMobilityService implements SmsService<LinkMobilitySendSmsReques
         var request = mapFromSmsRequest(smsRequest);
 
         return Optional.ofNullable(restTemplate.postForObject("/sms/send", new HttpEntity<>(request, createHeaders()), LinkMobilityResponse.class))
-                .map(LinkMobilityResponse::getStatus)
-                .map(ResponseStatus::isSent)
-                .orElse(false);
+            .map(LinkMobilityResponse::getStatus)
+            .map(ResponseStatus::isSent)
+            .orElse(false);
     }
 
     @Override
     public LinkMobilitySendSmsRequest mapFromSmsRequest(SendSmsRequest smsRequest) {
         return LinkMobilitySendSmsRequest.builder()
-                .withPlatformId(properties.getPlatformId())
-                .withPlatformPartnerId(properties.getPlatformPartnerId())
-                .withDestination("+46" + smsRequest.getMobileNumber().substring(1))
-                .withSource(smsRequest.getSender().getName())
-                .withUserData(smsRequest.getMessage())
-                .build();
+            .withPlatformId(properties.getPlatformId())
+            .withPlatformPartnerId(properties.getPlatformPartnerId())
+            .withDestination("+46" + smsRequest.getMobileNumber().substring(1))
+            .withSource(smsRequest.getSender().getName())
+            .withUserData(smsRequest.getMessage())
+            .build();
     }
 }

--- a/src/main/java/se/sundsvall/smssender/integration/linkmobility/domain/ResponseStatus.java
+++ b/src/main/java/se/sundsvall/smssender/integration/linkmobility/domain/ResponseStatus.java
@@ -98,8 +98,8 @@ public enum ResponseStatus {
     @JsonCreator
     public static ResponseStatus forValue(final int value) {
         return Arrays.stream(ResponseStatus.values())
-                .filter(status -> value == status.value)
-                .findFirst()
-                .orElse(null);
+            .filter(status -> value == status.value)
+            .findFirst()
+            .orElse(null);
     }
 }

--- a/src/main/java/se/sundsvall/smssender/integration/support/ConfiguredProviderCondition.java
+++ b/src/main/java/se/sundsvall/smssender/integration/support/ConfiguredProviderCondition.java
@@ -1,0 +1,21 @@
+package se.sundsvall.smssender.integration.support;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import se.sundsvall.smssender.integration.Provider;
+import se.sundsvall.smssender.integration.support.annotation.ConditionalOnConfiguredProvider;
+
+public class ConfiguredProviderCondition implements Condition {
+
+    @Override
+    public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+        var configuredProvider = Provider.fromValue(context.getEnvironment().getRequiredProperty("integration.sms.provider"));
+        var annotation = metadata.getAnnotations().get(ConditionalOnConfiguredProvider.class);
+
+        return annotation.getValue("value", Provider.class)
+            .map(annotatedProvider -> annotatedProvider == configuredProvider)
+            .orElse(false);
+    }
+}

--- a/src/main/java/se/sundsvall/smssender/integration/support/annotation/ConditionalOnConfiguredProvider.java
+++ b/src/main/java/se/sundsvall/smssender/integration/support/annotation/ConditionalOnConfiguredProvider.java
@@ -1,0 +1,19 @@
+package se.sundsvall.smssender.integration.support.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Conditional;
+
+import se.sundsvall.smssender.integration.Provider;
+import se.sundsvall.smssender.integration.support.ConfiguredProviderCondition;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Conditional(ConfiguredProviderCondition.class)
+public @interface ConditionalOnConfiguredProvider {
+
+    Provider value();
+}

--- a/src/main/java/se/sundsvall/smssender/integration/telia/TeliaSmsService.java
+++ b/src/main/java/se/sundsvall/smssender/integration/telia/TeliaSmsService.java
@@ -1,7 +1,5 @@
 package se.sundsvall.smssender.integration.telia;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Service;
@@ -10,25 +8,25 @@ import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 
 import se.sundsvall.smssender.api.model.SendSmsRequest;
+import se.sundsvall.smssender.integration.Provider;
 import se.sundsvall.smssender.integration.SmsService;
+import se.sundsvall.smssender.integration.support.annotation.ConditionalOnConfiguredProvider;
 import se.sundsvall.smssender.integration.telia.domain.TeliaResponse;
 import se.sundsvall.smssender.integration.telia.domain.TeliaSendSmsRequest;
 
 @Service
-public class TeliaService implements SmsService<TeliaSendSmsRequest> {
-
-    private static final Logger LOG = LoggerFactory.getLogger(TeliaService.class);
+@ConditionalOnConfiguredProvider(Provider.TELIA)
+public class TeliaSmsService implements SmsService<TeliaSendSmsRequest> {
 
     private final RestTemplate restTemplate;
 
-    public TeliaService(@Qualifier("integration.telia.resttemplate") RestTemplate restTemplate) {
+    public TeliaSmsService(@Qualifier("integration.telia.resttemplate") RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
     }
 
     @Override
     public boolean sendSms(SendSmsRequest sms) {
         var request = mapFromSmsRequest(sms);
-        LOG.debug(request.toString());
 
         var response = restTemplate.postForObject("/sendSms", new HttpEntity<>(request, createHeaders()), TeliaResponse.class);
 

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: '@project.version@'
+  version: "1.0"
 servers:
 - url: http://localhost:8080
   description: Generated server url
@@ -23,6 +23,12 @@ paths:
               $ref: '#/components/schemas/SendSmsRequest'
         required: true
       responses:
+        "200":
+          description: Successful Operation
+          content:
+            '*/*':
+              schema:
+                type: boolean
         "400":
           description: Bad Request
           content:
@@ -35,12 +41,6 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/Problem'
-        "200":
-          description: Successful Operation
-          content:
-            '*/*':
-              schema:
-                type: boolean
   /api-docs:
     get:
       tags:
@@ -98,18 +98,18 @@ components:
           type: object
           additionalProperties:
             type: object
-        title:
-          type: string
         status:
           $ref: '#/components/schemas/StatusType'
+        title:
+          type: string
         detail:
           type: string
     StatusType:
       type: object
       properties:
-        reasonPhrase:
-          type: string
         statusCode:
           type: integer
           format: int32
+        reasonPhrase:
+          type: string
   securitySchemes: {}

--- a/src/test/java/se/sundsvall/smssender/integration/linkmobility/LinkMobilitySmsServiceTest.java
+++ b/src/test/java/se/sundsvall/smssender/integration/linkmobility/LinkMobilitySmsServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static se.sundsvall.smssender.integration.linkmobility.LinkMobilityService.PREFIX;
+import static se.sundsvall.smssender.integration.linkmobility.LinkMobilitySmsService.PREFIX;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,21 +24,21 @@ import se.sundsvall.smssender.integration.linkmobility.domain.ResponseStatus;
 
 @ActiveProfiles("junit")
 @ExtendWith(MockitoExtension.class)
-class LinkMobilityServiceTest {
+class LinkMobilitySmsServiceTest {
 
     @Mock
     private LinkMobilityProperties mockProperties;
     @Mock
     private RestTemplate mockRestTemplate;
 
-    private LinkMobilityService service;
+    private LinkMobilitySmsService service;
 
     @BeforeEach
     void initMapper() {
         when(mockProperties.getPlatformId()).thenReturn("platformId");
         when(mockProperties.getPlatformPartnerId()).thenReturn("platformPartnerId");
 
-        service = new LinkMobilityService(mockProperties, mockRestTemplate);
+        service = new LinkMobilitySmsService(mockProperties, mockRestTemplate);
     }
 
     @Test

--- a/src/test/java/se/sundsvall/smssender/integration/telia/TeliaSmsServiceTest.java
+++ b/src/test/java/se/sundsvall/smssender/integration/telia/TeliaSmsServiceTest.java
@@ -22,16 +22,16 @@ import se.sundsvall.smssender.integration.telia.domain.TeliaResponse;
 
 @ActiveProfiles("junit")
 @ExtendWith(MockitoExtension.class)
-class TeliaServiceTest {
+class TeliaSmsServiceTest {
 
     @Mock
     private RestTemplate mockRestTemplate;
 
-    private TeliaService service;
+    private TeliaSmsService service;
 
     @BeforeEach
     void initMapper() {
-        service = new TeliaService(mockRestTemplate);
+        service = new TeliaSmsService(mockRestTemplate);
     }
 
     @Test


### PR DESCRIPTION
Changes so that a proper response is returned instead of a single boolean.

Also, changes the way the SMS provider is selected and changes the corresponding
beans so that only one of them is loaded, instead of both